### PR TITLE
Use singleton to get the instance of SkyBlock

### DIFF
--- a/src/mehrbod1gamer/GenUI/main.php
+++ b/src/mehrbod1gamer/GenUI/main.php
@@ -14,6 +14,7 @@ use pocketmine\Player;
 use pocketmine\plugin\PluginBase;
 use pocketmine\utils\Config;
 use pocketmine\utils\TextFormat;
+use room17\SkyBlock\SkyBlock;
 use room17\SkyBlock\event\island\IslandCreateEvent;
 use room17\SkyBlock\event\island\IslandDisbandEvent;
 
@@ -46,7 +47,7 @@ class main extends PluginBase implements  Listener
 
     public function onEnable()
     {
-        $this->skyblock = $this->getServer()->getPluginManager()->getPlugin("SkyBlock");
+        $this->skyblock = SkyBlock::getInstance();
         $this->saveDefaultConfig();
         $this->reloadConfig();
         self::$levelsDB = new Config($this->getDataFolder() . "levels.json", Config::JSON);


### PR DESCRIPTION
Use singleton to get the instance of SkyBlock and don't get the plugin by the name. Since people can just rename the SkyBlock plugin in plugin.yml and break this plugin.

However there is no singleton in EcnonomyAPI so you cannot get the EconomyAPI instance with singleton at the moment.